### PR TITLE
Use 'seed' roles to guarantee we don't init cluster singleton too early

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,9 @@
 import com.typesafe.sbt.SbtMultiJvm
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val akkaVersion = "2.3.1"
+val akkaVersion = "2.3.0" // todo upgrade to 2.3.2 once released!
+// 2.3.1 has a bug in clustering that stops the cluster from starting
+// when we use `xxxx.min-nr-of-members = 2`. Please use 2.3.0 for now, until 2.3.2 is out!
 
 val project = Project(
   id = "akka-sample-cluster-scala",

--- a/src/main/scala/sample/cluster/simple/SimpleClusterApp.scala
+++ b/src/main/scala/sample/cluster/simple/SimpleClusterApp.scala
@@ -10,8 +10,20 @@ object SimpleClusterApp {
   }
 
   def startup(port: String): Unit = {
+    // we mark the seed nodes with a special role, and will require those to join before we spin up the singleton
+    val maybeSeed = if (port startsWith "255") "roles = [seed]" else ""
+
     // Override the configuration of the port
     val config = ConfigFactory.parseString("akka.remote.netty.tcp.port=" + port).
+      withFallback(ConfigFactory.parseString(
+        s"""
+           |akka.cluster {
+           |  $maybeSeed
+           |  role {
+           |    seed.min-nr-of-members = 2
+           |  }
+           |}
+           |""".stripMargin)).
       withFallback(ConfigFactory.load())
 
     // Create an Akka system


### PR DESCRIPTION
Hey there,
Here's one of the suggestions that will help a little to make the singleton more resilient.
I also opened an issue https://www.assembla.com/spaces/akka/simple_planner#/ticket:3986 so we can keep track of changes around this. For now I'll update the docs with some patterns.

This relates to: https://groups.google.com/forum/#!topic/akka-user/ns7DPHGYbIk (where I'm currently finishing a big write up why this happens and what we can do about it).

Thanks for bringing this up, 
happy hakking!
